### PR TITLE
feat: allow tuples instead of geodomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ from the_census import GeoDomain
 census.get_geography_codes(GeoDomain("state", "*"))
 ```
 
-Of, if you don't want to import `GeoDomain`, and prefer to use tuples:
+Or, if you don't want to import `GeoDomain`, and prefer to use tuples:
 
 ```python
 census.get_geography_codes(("state", "*"))
@@ -137,7 +137,7 @@ census.get_geography_codes(GeoDomain("school district", "*"),
                            GeoDomain("state", "08"))
 ```
 
-Of, if you don't want to import `GeoDomain`, and prefer to use tuples:
+Or, if you don't want to import `GeoDomain`, and prefer to use tuples:
 
 ```python
 census.get_geography_codes(("school district", "*"),

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Census.list_available_datasets()
 
 This will present you with a pandas DataFrame listing all available datasets from the US Census API. (This includes only aggregate datasets, as they other types [of which there are very few] don't play nice with the client).
 
+### Help with terminology
+
+Some of the terms used in the data returned can be a bit opaque. To get a clearer sense of what some of those mean, run this:
+
+```python
+Census.help()
+```
+
+This will print out links to documentation for various datasets, along with what their group/variable names mean, and how statistics were calculated.
+
 ### Selecting a dataset
 
 Before getting started, you need to [get a Census API key](https://api.census.gov/data/key_signup.html), and set the following the environment variable `CENSUS_API_KEY` to whatever that key is, either with
@@ -94,6 +104,12 @@ census.get_supported_geographies()
 
 This will output a DataFrame will all possible supported geographies (e.g., if I can query all school districts across all states).
 
+If you don't want to have to keep on typing supported geographies after this, you can use tab-completion in Jupyter by typing:
+
+```python
+census.supported_geographies.<TAB>
+```
+
 ### Geography codes
 
 If you decide you want to query a particular geography (e.g., a particular school district within a particular state), you'll need the [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standard_state_code#FIPS_state_codes) codes for that school district and state.
@@ -108,11 +124,24 @@ from the_census import GeoDomain
 census.get_geography_codes(GeoDomain("state", "*"))
 ```
 
+Of, if you don't want to import `GeoDomain`, and prefer to use tuples:
+
+```python
+census.get_geography_codes(("state", "*"))
+```
+
 2. Get FIPS codes for all school districts within Colorado (FIPS code `08`):
 
 ```python
 census.get_geography_codes(GeoDomain("school district", "*"),
                            GeoDomain("state", "08"))
+```
+
+Of, if you don't want to import `GeoDomain`, and prefer to use tuples:
+
+```python
+census.get_geography_codes(("school district", "*"),
+                           ("state", "08"))
 ```
 
 Note that geography code queries must follow supported geography guidelines.
@@ -193,11 +222,21 @@ Once you have the variables you want to query, along with the geography you're i
 ```python
 from the_census import GeoDomain
 
-variables = census.getvariables_for_group(census.groups.SexByAge)
+variables = census.get_variables_for_group(census.groups.SexByAge)
 
 census.get_stats(variables["code"].tolist(),
                  GeoDomain("school district", "*"),
                  GeoDomain("state", "08"))
+```
+
+Or, if you'd rather use tuples instead of `GeoDomain`:
+
+```python
+variables = census.get_variables_for_group(census.groups.SexByAge)
+
+census.get_stats(variables["code"].tolist(),
+                 ("school district", "*"),
+                 ("state", "08"))
 ```
 
 ## Dataset "architecture"
@@ -213,6 +252,8 @@ US Census datasets have 3 primary components:
 A group is a "category" of data gathered for a particular census. For example, the `SEX BY AGE` group would provide breakdowns of gender and age demographics in a given region in the United States.
 
 Some of these groups' names, however, are a not as clear as `SEX BY AGE`. In that case, I recommend heading over to the survey in question's [technical documentation](https://www2.census.gov/programs-surveys/) which elaborates on what certain terms mean with respect to particular groups. Unfortunately, the above link might be complicated to navigate, but if you're looking for ACS group documentation, [here's](https://www2.census.gov/programs-surveys/acs/tech_docs/subject_definitions/2019_ACSSubjectDefinitions.pdf) a handy link.
+
+(You can also get these links by running `Census.help()`.)
 
 ### Variables
 

--- a/tests/integration/census/census_test.py
+++ b/tests/integration/census/census_test.py
@@ -14,7 +14,7 @@ from tests.integration.census.mock_api_responses import MOCK_API
 from tests.utils import MockRes
 from the_census import Census, GeoDomain
 from the_census._exceptions import CensusDoesNotExistException, NoCensusApiKeyException
-from the_census._helpers import GeoDomainTypes
+from the_census._geographies.models import GeoDomainTypes
 from the_census._utils.clean_variable_name import clean_variable_name
 from the_census._variables.models import Group, GroupCode, GroupVariable, VariableCode
 from the_census._variables.repository.models import GroupSet, VariableSet

--- a/the_census/_client.py
+++ b/the_census/_client.py
@@ -87,18 +87,11 @@ class CensusClient:
 
     # helpers
 
-    def __convert_to_geo_domain(self, geo_domain: GeoDomainTypes) -> GeoDomain:  # type: ignore (checker gets upset since there's no return after the `else`)
+    def __convert_to_geo_domain(self, geo_domain: GeoDomainTypes) -> GeoDomain:
         if isinstance(geo_domain, GeoDomain):
             return geo_domain
-        elif isinstance(geo_domain, tuple):  # type: ignore
-            if not all([isinstance(i, str) for i in geo_domain]):  # type: ignore
-                raise ValueError("GeoDomain params must be strings")
-            if len(geo_domain) == 2:
-                return GeoDomain(geo_domain[0], geo_domain[1])
-            elif len(geo_domain) == 1:
-                return GeoDomain(geo_domain[0])
         else:
-            raise ValueError("geo_domain is not of correct type")
+            return GeoDomain.from_tuple(geo_domain)
 
     # property variables for Jupyter notebook usage
 

--- a/the_census/_client.py
+++ b/the_census/_client.py
@@ -4,8 +4,7 @@ import pandas as pd
 
 from the_census._api.fetch import ICensusApiFetchService
 from the_census._geographies.interface import IGeographyRepository
-from the_census._geographies.models import GeoDomain, SupportedGeoSet
-from the_census._helpers import GeoDomainTypes
+from the_census._geographies.models import GeoDomain, GeoDomainTypes, SupportedGeoSet
 from the_census._stats.interface import ICensusStatisticsService
 from the_census._variables.models import GroupCode, VariableCode
 from the_census._variables.repository.interface import IVariableRepository
@@ -57,8 +56,8 @@ class CensusClient:
         self, for_domain: GeoDomainTypes, *in_domains: GeoDomainTypes
     ) -> pd.DataFrame:
         return self._geo_repo.get_geography_codes(
-            self.__convert_to_geo_domain(for_domain),
-            *[self.__convert_to_geo_domain(in_domain) for in_domain in in_domains],
+            GeoDomain._from(for_domain),
+            *[GeoDomain._from(in_domain) for in_domain in in_domains],
         ).copy(deep=True)
 
     def get_groups(self) -> pd.DataFrame:
@@ -81,17 +80,11 @@ class CensusClient:
     ) -> pd.DataFrame:
         return self._stats.get_stats(
             variables_to_query,
-            self.__convert_to_geo_domain(for_domain),
-            *[self.__convert_to_geo_domain(in_domain) for in_domain in in_domains],
+            GeoDomain._from(for_domain),
+            *[GeoDomain._from(in_domain) for in_domain in in_domains],
         ).copy(deep=True)
 
     # helpers
-
-    def __convert_to_geo_domain(self, geo_domain: GeoDomainTypes) -> GeoDomain:
-        if isinstance(geo_domain, GeoDomain):
-            return geo_domain
-        else:
-            return GeoDomain.from_tuple(geo_domain)
 
     # property variables for Jupyter notebook usage
 

--- a/the_census/_geographies/models.py
+++ b/the_census/_geographies/models.py
@@ -39,6 +39,6 @@ class SupportedGeoSet:
     def __init__(self) -> None:
         super().__init__()
 
-    def add(self, *geoName: str):
-        mapping = {clean_variable_name(name): name for name in geoName}
+    def add(self, *geo_name: str):
+        mapping = {clean_variable_name(name): name for name in geo_name}
         self.__dict__.update(mapping)

--- a/the_census/_geographies/models.py
+++ b/the_census/_geographies/models.py
@@ -3,6 +3,8 @@ from typing import Tuple, Union
 
 from the_census._utils.clean_variable_name import clean_variable_name
 
+GeoDomainTypes = Union["GeoDomain", Tuple[str, str], Tuple[str]]
+
 
 @dataclass(frozen=True)
 class GeoDomain:
@@ -16,9 +18,10 @@ class GeoDomain:
         return f"{self.name}:{self.code_or_wildcard}"
 
     @classmethod
-    def from_tuple(
+    def _from(
         cls,
-        tuple_geo_domain: Union[
+        geo_domain: Union[
+            "GeoDomain",
             Tuple[
                 str,
                 str,
@@ -26,7 +29,10 @@ class GeoDomain:
             Tuple[str],
         ],
     ) -> "GeoDomain":
-        return cls(*tuple_geo_domain)
+        if isinstance(geo_domain, GeoDomain):
+            return cls(geo_domain.name, geo_domain.code_or_wildcard)
+        else:
+            return cls(*geo_domain)
 
 
 class SupportedGeoSet:

--- a/the_census/_geographies/models.py
+++ b/the_census/_geographies/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Tuple, Union
 
 from the_census._utils.clean_variable_name import clean_variable_name
 
@@ -13,6 +14,19 @@ class GeoDomain:
 
     def __repr__(self) -> str:
         return f"{self.name}:{self.code_or_wildcard}"
+
+    @classmethod
+    def from_tuple(
+        cls,
+        tuple_geo_domain: Union[
+            Tuple[
+                str,
+                str,
+            ],
+            Tuple[str],
+        ],
+    ) -> "GeoDomain":
+        return cls(*tuple_geo_domain)
 
 
 class SupportedGeoSet:

--- a/the_census/_geographies/service.py
+++ b/the_census/_geographies/service.py
@@ -1,6 +1,6 @@
 from functools import cache
 from logging import Logger
-from typing import Tuple
+from typing import List, Tuple, cast
 
 import pandas as pd
 
@@ -35,6 +35,8 @@ class GeographyRepository(IGeographyRepository[pd.DataFrame]):
         self._logger = logger_factory.getLogger(__name__)
 
         self._supported_geographies = SupportedGeoSet()
+
+        self.__populate_repository()
 
     @timer
     def get_geography_codes(
@@ -84,3 +86,16 @@ class GeographyRepository(IGeographyRepository[pd.DataFrame]):
         self._supported_geographies.add(*df["name"].tolist())
 
         return df
+
+    def __populate_repository(self) -> None:
+        self._logger.debug("Trying to populate geography repository")
+
+        df = self._cache.get(SUPPORTED_GEOS_FILE)
+
+        if df is None or df.empty:
+            self._logger.debug("Could not populate geography repository")
+            return
+
+        self._supported_geographies.add(*set(cast(List[str], df["name"].tolist())))
+
+        self._logger.debug("Populated geography repository")

--- a/the_census/_helpers.py
+++ b/the_census/_helpers.py
@@ -1,19 +1,15 @@
 from dataclasses import dataclass
 from functools import cache
-from typing import Any, Dict, List, Tuple, Union, cast
+from typing import Any, Dict, List, cast
 
 import pandas
 import pandas as pd
 import requests
 from tqdm.notebook import tqdm
 
-from the_census._geographies.models import GeoDomain
-
 URL = "https://api.census.gov/data.json"
 
 # documentation: https://www2.census.gov/programs-surveys/acs/tech_docs/subject_definitions/
-
-GeoDomainTypes = Union[GeoDomain, Tuple[str, str], Tuple[str]]
 
 
 @dataclass(frozen=True)

--- a/the_census/_helpers.py
+++ b/the_census/_helpers.py
@@ -1,15 +1,19 @@
 from dataclasses import dataclass
 from functools import cache
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Tuple, Union, cast
 
 import pandas
 import pandas as pd
 import requests
 from tqdm.notebook import tqdm
 
+from the_census._geographies.models import GeoDomain
+
 URL = "https://api.census.gov/data.json"
 
 # documentation: https://www2.census.gov/programs-surveys/acs/tech_docs/subject_definitions/
+
+GeoDomainTypes = Union[GeoDomain, Tuple[str, str], Tuple[str]]
 
 
 @dataclass(frozen=True)

--- a/the_census/census.py
+++ b/the_census/census.py
@@ -19,9 +19,9 @@ from the_census._data_transformation.interface import ICensusDataTransformer
 from the_census._data_transformation.service import CensusDataTransformer
 from the_census._exceptions import NoCensusApiKeyException
 from the_census._geographies.interface import IGeographyRepository
-from the_census._geographies.models import SupportedGeoSet
+from the_census._geographies.models import GeoDomainTypes, SupportedGeoSet
 from the_census._geographies.service import GeographyRepository
-from the_census._helpers import GeoDomainTypes, list_available_datasets
+from the_census._helpers import list_available_datasets
 from the_census._persistence.interface import ICache
 from the_census._persistence.onDisk import OnDiskCache
 from the_census._stats.interface import ICensusStatisticsService

--- a/the_census/census.py
+++ b/the_census/census.py
@@ -19,9 +19,9 @@ from the_census._data_transformation.interface import ICensusDataTransformer
 from the_census._data_transformation.service import CensusDataTransformer
 from the_census._exceptions import NoCensusApiKeyException
 from the_census._geographies.interface import IGeographyRepository
-from the_census._geographies.models import GeoDomain, SupportedGeoSet
+from the_census._geographies.models import SupportedGeoSet
 from the_census._geographies.service import GeographyRepository
-from the_census._helpers import list_available_datasets
+from the_census._helpers import GeoDomainTypes, list_available_datasets
 from the_census._persistence.interface import ICache
 from the_census._persistence.onDisk import OnDiskCache
 from the_census._stats.interface import ICensusStatisticsService
@@ -146,7 +146,7 @@ class Census:
 
     # repo
     def get_geography_codes(
-        self, for_domain: GeoDomain, *in_domains: GeoDomain
+        self, for_domain: GeoDomainTypes, *in_domains: GeoDomainTypes
     ) -> pandas.DataFrame:
         """
         Gets geography codes for the specified geography query.
@@ -212,8 +212,8 @@ class Census:
     def get_stats(
         self,
         variables_to_query: List[VariableCode],
-        for_domain: GeoDomain,
-        *in_domains: GeoDomain,
+        for_domain: GeoDomainTypes,
+        *in_domains: GeoDomainTypes,
     ) -> pandas.DataFrame:
         """
         Gets statistical data based on `variables_to_query`


### PR DESCRIPTION
Instead of needing to import & pass in `GeoDomain` like so:

```python
from the_census import Census, GeoDomain

c = Census(...)

c.get_geography_codes(GeoDomain("state", "09"))
```

now you can alternatively use tuples:

```python
from the_census import Census, GeoDomain

c = Census(...)

c.get_geography_codes(("state", "09"))
```